### PR TITLE
msfar merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-INCS= system.h base.h config.h task.h queue.h smphr.h mutex.h
+INCS= system.h base.h config.h task.h queue.h smphr.h mutex.h timer.h
 
 EXAMPLESDIR= examples
-EXMPLS= simple semaphore queues
+EXMPLS= simple semaphore queues timer timer-test
 EXBINS= $(patsubst %,$(EXAMPLESDIR)/%,$(EXMPLS))
 
 SYSTEM?= posix

--- a/examples/queues.c
+++ b/examples/queues.c
@@ -16,7 +16,7 @@ void producer(void *arg)
     for(;;) {
         system_delay(id * 1000);
         printf("Producer %u pushed\n", (unsigned int)id);
-        queue_push(&q, &id, 1000);
+        queue_push(q, &id, 1000);
     }
 }
 
@@ -26,7 +26,7 @@ void consumer(void *arg)
 
     for(;;) {
         uintptr_t data;
-        if(queue_pop(&q, &data, 800)) {
+        if(queue_pop(q, &data, 800)) {
             printf("Consumer received: %u\n", (unsigned int)data);
             continue;
         }
@@ -51,7 +51,7 @@ int main(void)
     }
     
     system_start();
-    queue_destroy(&q);
+    queue_destroy(q);
 
     return 0;
 }

--- a/examples/semaphore.c
+++ b/examples/semaphore.c
@@ -11,12 +11,12 @@ smphr_t s;
 void task(void* arg)
 {
     uintptr_t id = (uintptr_t)arg;
-    smphr_take(&s, 1000);
+    smphr_take(s, 1000);
 
     printf("Task %d has the semaphore\n", (unsigned int)id);
     system_delay(500);
     printf("Task %d gives the semaphore\n", (unsigned int)id);
-    smphr_give(&s);
+    smphr_give(s);
 }
 
 int main(void)
@@ -35,7 +35,7 @@ int main(void)
     task_create(&task2h, task, (void*)2, NULL, 0, 0);
 
     system_start();
-    smphr_destroy(&s);
+    smphr_destroy(s);
 
     return 0;
 }

--- a/examples/semaphore.c
+++ b/examples/semaphore.c
@@ -4,6 +4,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 smphr_t s;
 
@@ -28,7 +29,7 @@ int main(void)
     printf("System abstraction test - POSIX implementation\n");
     printf("Semaphore example application\n");
 
-    smphr_init(&s, 1, NULL);
+    smphr_init(&s, false, NULL);
 
     task_create(&task1h, task, (void*)1, NULL, 0, 0);
     task_create(&task2h, task, (void*)2, NULL, 0, 0);
@@ -38,3 +39,4 @@ int main(void)
 
     return 0;
 }
+

--- a/examples/timer-test.c
+++ b/examples/timer-test.c
@@ -138,14 +138,14 @@ int main(void)
 
     system_init();
 
-    tmr_create(&test_timer, true, test, NULL);
+    tmr_init(&test_timer, true, test, NULL);
     tmr_start(&test_timer, 250);
-    tmr_create(&test_timer_2, true, test_2, NULL);
+    tmr_init(&test_timer_2, true, test_2, NULL);
     tmr_start(&test_timer_2, 100);
-    tmr_create(&test_timer_3, true, test_3, NULL);
-    tmr_create(&test_timer_4, true, test_4, NULL);
-    tmr_create(&test_timer_5, true, test_5, NULL);
-    tmr_create(&test_timer_6, true, test_6, NULL);
+    tmr_init(&test_timer_3, true, test_3, NULL);
+    tmr_init(&test_timer_4, true, test_4, NULL);
+    tmr_init(&test_timer_5, true, test_5, NULL);
+    tmr_init(&test_timer_6, true, test_6, NULL);
     task_create(&test_task, test_others, NULL, NULL, 0, 0);
     task_create(&test_task_2, test_reset, NULL, NULL, 0, 0);
 

--- a/examples/timer-test.c
+++ b/examples/timer-test.c
@@ -1,8 +1,9 @@
+#include <system/system.h>
+#include <system/timer.h>
+#include <system/task.h>
+
 #include <stddef.h>
 #include <stdio.h>
-#include <system/timer.h>
-#include <system/system.h>
-#include <system/task.h>
 #include <stdbool.h>
 
 tmr_t test_timer, test_timer_2, test_timer_3, test_timer_4, test_timer_5, test_timer_6;
@@ -132,10 +133,11 @@ void test_others(void* arg)
 int main(void)
 {
     task_t test_task, test_task_2;
-    
+
     printf("System abstraction test - POSIX implementation\n");
 
     system_init();
+
     tmr_create(&test_timer, true, test, NULL);
     tmr_start(&test_timer, 250);
     tmr_create(&test_timer_2, true, test_2, NULL);
@@ -146,7 +148,15 @@ int main(void)
     tmr_create(&test_timer_6, true, test_6, NULL);
     task_create(&test_task, test_others, NULL, NULL, 0, 0);
     task_create(&test_task_2, test_reset, NULL, NULL, 0, 0);
+
     system_start();
-    
+
+    tmr_destroy(test_timer);
+    tmr_destroy(test_timer_2);
+    tmr_destroy(test_timer_3);
+    tmr_destroy(test_timer_4);
+    tmr_destroy(test_timer_5);
+    tmr_destroy(test_timer_6);
+
     return 0;
 }

--- a/examples/timer-test.c
+++ b/examples/timer-test.c
@@ -1,0 +1,152 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <system/timer.h>
+#include <system/system.h>
+#include <system/task.h>
+#include <stdbool.h>
+
+tmr_t test_timer, test_timer_2, test_timer_3, test_timer_4, test_timer_5, test_timer_6;
+int global_flag = 0;
+int test_timer_4_flag = 3;
+int full_time = 0;
+
+void start()
+{
+    if (global_flag == 30){
+        test_timer_4_flag = 0;
+    }
+    else if (global_flag == 34){
+        test_timer_4_flag = 1;
+    }
+    else if (global_flag > 38){
+        test_timer_4_flag = 2;
+    }
+    global_flag++;
+}
+
+void test()
+{    
+    full_time +=250;
+    printf("--------------- 250 (%d) ms ---------------\n", full_time);
+    start();
+}
+void test_2()
+{
+    printf("Timer 2 wake up at -> %d (%d) tick \n", system_get_tick_count(), test_timer_2.period);
+}
+void test_3()
+{
+    printf("Timer 3 wake up at -> %d (%d) tick \n", system_get_tick_count(), test_timer_3.period);
+}
+void test_4()
+{    
+    printf("Timer 4 wake up at -> %d (%d) tick \n", system_get_tick_count(), test_timer_4.period);
+}
+void test_5()
+{    
+    printf("Timer 5 wake up at -> %d (%d) tick \n", system_get_tick_count(), test_timer_5.period);
+}
+void test_6()
+{    
+    printf("Timer 6 wake up at -> %d (%d) tick \n", system_get_tick_count(), test_timer_6.period);
+}
+
+void test_reset(void* arg)
+{
+    bool flag = true;
+
+    
+    while (1){
+        system_delay(99);
+        if (full_time > 2500 && full_time < 12500)
+        {
+                tmr_stop(&test_timer_2);
+                system_delay(250);
+        }
+        else if (full_time > 500 && full_time <2501){
+            if (flag){
+                tmr_reset(&test_timer_2);
+            }
+            flag = !flag;
+        }
+    }
+}
+
+void test_others(void* arg)
+{
+    printf("-------------------Schedule-----------------\n");
+    printf("Timer 2 reset test starts at ----> 500 ms \n");
+    printf("Timer 2 reset test ends at   ----> 2500 ms \n");
+    printf("Timer 3 starts at            ----> 2000 ms \n");
+    printf("Timer 3 stops at             ----> 3500 ms \n");
+    printf("Timer 3 starts at            ----> 4500 ms \n");
+    printf("Timer 5 starts at            ----> 5000 period 1000  ms \n");
+    printf("Timer 6 starts at            ----> 5250 period 500 ms \n");
+    printf("Timer 4 starts at            ----> 7500 ms \n");
+    printf("Timer 4 stops at             ----> 8500 ms \n");
+    printf("Timer 4 reset stop at        ----> 9500 ms \n");
+    printf("Timer 4 starts at            ----> 12500 ms \n");
+    printf("Timer 1 stops at             ----> 12500 ms \n");
+    printf("--------------------------------------------\n");
+
+    while(true) {
+        system_delay(50);
+        switch (full_time){
+            case 2000:
+                tmr_start(&test_timer_3,250);
+                break;
+            case 3500:
+                tmr_stop(&test_timer_3);
+                break;
+            case 4500:
+                tmr_start(&test_timer_3,500);
+                break;
+            case 5000:
+                tmr_start(&test_timer_5, 1000);
+                break;
+            case 5250:
+                tmr_start(&test_timer_6, 500);
+                break;
+            case 12500:
+                tmr_stop(&test_timer);
+                tmr_start(&test_timer_2,250);
+                full_time += 1;
+                break;
+        }
+        
+        if (test_timer_4_flag == 0){
+            tmr_start(&test_timer_4, 500);
+            test_timer_4_flag = 3;
+        }
+        else if (test_timer_4_flag == 1){
+            tmr_stop(&test_timer_4);
+            test_timer_4_flag = 3;
+        }
+        else if (test_timer_4_flag == 2){
+            tmr_reset(&test_timer_4);
+            test_timer_4_flag = 3;
+        }
+    }
+}
+
+int main(void)
+{
+    task_t test_task, test_task_2;
+    
+    printf("System abstraction test - POSIX implementation\n");
+
+    system_init();
+    tmr_create(&test_timer, true, test, NULL);
+    tmr_start(&test_timer, 250);
+    tmr_create(&test_timer_2, true, test_2, NULL);
+    tmr_start(&test_timer_2, 100);
+    tmr_create(&test_timer_3, true, test_3, NULL);
+    tmr_create(&test_timer_4, true, test_4, NULL);
+    tmr_create(&test_timer_5, true, test_5, NULL);
+    tmr_create(&test_timer_6, true, test_6, NULL);
+    task_create(&test_task, test_others, NULL, NULL, 0, 0);
+    task_create(&test_task_2, test_reset, NULL, NULL, 0, 0);
+    system_start();
+    
+    return 0;
+}

--- a/examples/timer-test.c
+++ b/examples/timer-test.c
@@ -2,11 +2,13 @@
 #include <system/timer.h>
 #include <system/task.h>
 
+#include "posix-timer.h"
 #include <stddef.h>
 #include <stdio.h>
 #include <stdbool.h>
 
-tmr_t test_timer, test_timer_2, test_timer_3, test_timer_4, test_timer_5, test_timer_6;
+tmr_t test_timer, test_timer_2, test_timer_3,
+      test_timer_4, test_timer_5, test_timer_6;
 int global_flag = 0;
 int test_timer_4_flag = 3;
 int full_time = 0;
@@ -33,23 +35,28 @@ void test()
 }
 void test_2()
 {
-    printf("Timer 2 wake up at -> %d (%d) tick \n", system_get_tick_count(), test_timer_2.period);
+    printf("Timer 2 wake up at -> %d (%d) tick \n",
+           system_get_tick_count(), ((posix_timer_t*)(test_timer_2))->period);
 }
 void test_3()
 {
-    printf("Timer 3 wake up at -> %d (%d) tick \n", system_get_tick_count(), test_timer_3.period);
+    printf("Timer 3 wake up at -> %d (%d) tick \n",
+           system_get_tick_count(), ((posix_timer_t*)(test_timer_3))->period);
 }
 void test_4()
 {    
-    printf("Timer 4 wake up at -> %d (%d) tick \n", system_get_tick_count(), test_timer_4.period);
+    printf("Timer 4 wake up at -> %d (%d) tick \n",
+           system_get_tick_count(), ((posix_timer_t*)(test_timer_4))->period);
 }
 void test_5()
 {    
-    printf("Timer 5 wake up at -> %d (%d) tick \n", system_get_tick_count(), test_timer_5.period);
+    printf("Timer 5 wake up at -> %d (%d) tick \n",
+           system_get_tick_count(), ((posix_timer_t*)(test_timer_5))->period);
 }
 void test_6()
 {    
-    printf("Timer 6 wake up at -> %d (%d) tick \n", system_get_tick_count(), test_timer_6.period);
+    printf("Timer 6 wake up at -> %d (%d) tick \n",
+           system_get_tick_count(), ((posix_timer_t*)(test_timer_6))->period);
 }
 
 void test_reset(void* arg)
@@ -61,12 +68,12 @@ void test_reset(void* arg)
         system_delay(99);
         if (full_time > 2500 && full_time < 12500)
         {
-                tmr_stop(&test_timer_2);
+                tmr_stop(test_timer_2);
                 system_delay(250);
         }
         else if (full_time > 500 && full_time <2501){
             if (flag){
-                tmr_reset(&test_timer_2);
+                tmr_reset(test_timer_2);
             }
             flag = !flag;
         }
@@ -94,37 +101,37 @@ void test_others(void* arg)
         system_delay(50);
         switch (full_time){
             case 2000:
-                tmr_start(&test_timer_3,250);
+                tmr_start(test_timer_3,250);
                 break;
             case 3500:
-                tmr_stop(&test_timer_3);
+                tmr_stop(test_timer_3);
                 break;
             case 4500:
-                tmr_start(&test_timer_3,500);
+                tmr_start(test_timer_3,500);
                 break;
             case 5000:
-                tmr_start(&test_timer_5, 1000);
+                tmr_start(test_timer_5, 1000);
                 break;
             case 5250:
-                tmr_start(&test_timer_6, 500);
+                tmr_start(test_timer_6, 500);
                 break;
             case 12500:
-                tmr_stop(&test_timer);
-                tmr_start(&test_timer_2,250);
+                tmr_stop(test_timer);
+                tmr_start(test_timer_2,250);
                 full_time += 1;
                 break;
         }
         
         if (test_timer_4_flag == 0){
-            tmr_start(&test_timer_4, 500);
+            tmr_start(test_timer_4, 500);
             test_timer_4_flag = 3;
         }
         else if (test_timer_4_flag == 1){
-            tmr_stop(&test_timer_4);
+            tmr_stop(test_timer_4);
             test_timer_4_flag = 3;
         }
         else if (test_timer_4_flag == 2){
-            tmr_reset(&test_timer_4);
+            tmr_reset(test_timer_4);
             test_timer_4_flag = 3;
         }
     }
@@ -139,9 +146,9 @@ int main(void)
     system_init();
 
     tmr_init(&test_timer, true, test, NULL);
-    tmr_start(&test_timer, 250);
+    tmr_start(test_timer, 250);
     tmr_init(&test_timer_2, true, test_2, NULL);
-    tmr_start(&test_timer_2, 100);
+    tmr_start(test_timer_2, 100);
     tmr_init(&test_timer_3, true, test_3, NULL);
     tmr_init(&test_timer_4, true, test_4, NULL);
     tmr_init(&test_timer_5, true, test_5, NULL);

--- a/examples/timer.c
+++ b/examples/timer.c
@@ -28,11 +28,11 @@ int main(void)
 
     system_init();
 
-    tmr_create(&test_timer, true, test, NULL);
+    tmr_init(&test_timer, true, test, NULL);
     tmr_start(&test_timer, 100);
-    tmr_create(&test_timer_2, true, test_2, NULL);
+    tmr_init(&test_timer_2, true, test_2, NULL);
     tmr_start(&test_timer_2, 275);
-    tmr_create(&test_timer_3, false, test_3, NULL);
+    tmr_init(&test_timer_3, false, test_3, NULL);
     tmr_start(&test_timer_3, 1000);
     tmr_stop(&test_timer);
     tmr_reset(&test_timer);

--- a/examples/timer.c
+++ b/examples/timer.c
@@ -1,8 +1,9 @@
+#include <system/system.h>
+#include <system/timer.h>
+#include <system/task.h>
+
 #include <stddef.h>
 #include <stdio.h>
-#include <system/timer.h>
-#include <system/system.h>
-#include <system/task.h>
 
 void test()
 {
@@ -22,10 +23,11 @@ void test_3()
 int main(void)
 {
     tmr_t test_timer, test_timer_2, test_timer_3;
-    
+
     printf("System abstraction test - POSIX implementation\n");
 
     system_init();
+
     tmr_create(&test_timer, true, test, NULL);
     tmr_start(&test_timer, 100);
     tmr_create(&test_timer_2, true, test_2, NULL);
@@ -34,8 +36,13 @@ int main(void)
     tmr_start(&test_timer_3, 1000);
     tmr_stop(&test_timer);
     tmr_reset(&test_timer);
+
     system_start();
-    
+
+    tmr_destroy(test_timer);
+    tmr_destroy(test_timer_2);
+    tmr_destroy(test_timer_3);
 
     return 0;
 }
+

--- a/examples/timer.c
+++ b/examples/timer.c
@@ -1,0 +1,41 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <system/timer.h>
+#include <system/system.h>
+#include <system/task.h>
+
+void test()
+{
+    printf("Timer 1 wake up at -> %d tick\n", system_get_tick_count());
+}
+void test_2()
+{
+    printf("Timer 2 wake up at -> %d tick\n", system_get_tick_count());
+}
+void test_3()
+{
+    printf("-----------------------------\n");
+    printf("Timer 3 wake up at -> %d tick\n", system_get_tick_count());
+    printf("-----------------------------\n");
+}
+
+int main(void)
+{
+    tmr_t test_timer, test_timer_2, test_timer_3;
+    
+    printf("System abstraction test - POSIX implementation\n");
+
+    system_init();
+    tmr_create(&test_timer, true, test, NULL);
+    tmr_start(&test_timer, 100);
+    tmr_create(&test_timer_2, true, test_2, NULL);
+    tmr_start(&test_timer_2, 275);
+    tmr_create(&test_timer_3, false, test_3, NULL);
+    tmr_start(&test_timer_3, 1000);
+    tmr_stop(&test_timer);
+    tmr_reset(&test_timer);
+    system_start();
+    
+
+    return 0;
+}

--- a/examples/timer.c
+++ b/examples/timer.c
@@ -29,13 +29,13 @@ int main(void)
     system_init();
 
     tmr_init(&test_timer, true, test, NULL);
-    tmr_start(&test_timer, 100);
+    tmr_start(test_timer, 100);
     tmr_init(&test_timer_2, true, test_2, NULL);
-    tmr_start(&test_timer_2, 275);
+    tmr_start(test_timer_2, 275);
     tmr_init(&test_timer_3, false, test_3, NULL);
-    tmr_start(&test_timer_3, 1000);
-    tmr_stop(&test_timer);
-    tmr_reset(&test_timer);
+    tmr_start(test_timer_3, 1000);
+    tmr_stop(test_timer);
+    tmr_reset(test_timer);
 
     system_start();
 

--- a/src/base.h
+++ b/src/base.h
@@ -9,14 +9,15 @@
 #  include <FreeRTOS/FreeRTOS.h>
 #  define SYSTEM_NO_WAIT                            ((portTickType)0)
 #  define SYSTEM_MAX_WAIT                           (portMAX_DELAY)
+#  define SYSTEM_TICK_RATE_MS                       (portTICK_RATE_MS)
 #  define SYSTEM_TASK_MODIFIER                      __task
 typedef portTickType system_tick_t;
 #elif SYSTEM_CONFIG_TYPE_POSIX == 1
 #  include <stdint.h>
 #  include <stdbool.h>
 
-#  if !defined(SYSTEM_CONFIG_POSIX_TICKS_1S)
-#    define SYSTEM_CONFIG_POSIX_TICKS_1S                  (1000)
+#  if !defined(SYSTEM_TICK_RATE_MS)
+#    define SYSTEM_TICK_RATE_MS                           (1000)
 #  endif
 
 #  if !defined(SYSTEM_CONFIG_POSIX_MAX_TASKS)

--- a/src/base.h
+++ b/src/base.h
@@ -17,11 +17,11 @@ typedef portTickType system_tick_t;
 #  include <stdbool.h>
 
 #  if !defined(SYSTEM_TICK_RATE_MS)
-#    define SYSTEM_TICK_RATE_MS                           (1000)
+#    define SYSTEM_TICK_RATE_MS                     (1000)
 #  endif
 
-#  if !defined(SYSTEM_CONFIG_POSIX_MAX_TASKS)
-#    define SYSTEM_CONFIG_POSIX_MAX_TASKS                 (10)
+#  if !defined(SYSTEM_CONFIG_MAX_TASKS)
+#    define SYSTEM_CONFIG_MAX_TASKS                 (10)
 #  endif
 
 /* type definitions */

--- a/src/config.h
+++ b/src/config.h
@@ -2,5 +2,6 @@
 #define __CONFIG_H__
 
 #define SYSTEM_CONFIG_MAX_TASKS                     (10)
+#define SYSTEM_CONFIG_USE_TIMERS                    (1)
 
 #endif /* __CONFIG_H__ */

--- a/src/freertos-mutex.c
+++ b/src/freertos-mutex.c
@@ -6,7 +6,6 @@
 #include <FreeRTOS/semphr.h>
 
 #include <stdbool.h>
-#include <stddef.h>
 
 bool
 mutex_init(mutex_t *m, const char *name)
@@ -25,11 +24,11 @@ mutex_init(mutex_t *m, const char *name)
 bool
 mutex_lock(mutex_t m, system_tick_t ticks)
 {
-    return xSemaphoreTake(*(xSemaphoreHandle *)m, ticks) == pdTRUE;
+    return xSemaphoreTake(m, ticks) == pdTRUE;
 }
 
 bool
 mutex_unlock(mutex_t m)
 {
-    return xSemaphoreGive(*(xSemaphoreHandle *)m) == pdTRUE;
+    return xSemaphoreGive(m) == pdTRUE;
 }

--- a/src/freertos-mutex.c
+++ b/src/freertos-mutex.c
@@ -24,11 +24,11 @@ mutex_init(mutex_t *m, const char *name)
 bool
 mutex_lock(mutex_t m, system_tick_t ticks)
 {
-    return xSemaphoreTake(m, ticks) == pdTRUE;
+    return xSemaphoreTake((xSemaphoreHandle)m, ticks) == pdTRUE;
 }
 
 bool
 mutex_unlock(mutex_t m)
 {
-    return xSemaphoreGive(m) == pdTRUE;
+    return xSemaphoreGive((xSemaphoreHandle)m) == pdTRUE;
 }

--- a/src/freertos-queue.c
+++ b/src/freertos-queue.c
@@ -35,6 +35,28 @@ queue_push(queue_t q, void *el, system_tick_t ticks)
 }
 
 bool
+queue_push_to_front(queue_t q, void *el, system_tick_t ticks)
+{
+
+    return xQueueSendToFront(q, el, ticks) == pdTRUE;
+}
+
+bool
+queue_isr_push(queue_t q, void *el, bool * const woken)
+{
+    portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
+    bool result;
+
+    result = (xQueueSendToBackFromISR(q, el,
+                                      &xHigherPriorityTaskWoken) == pdTRUE);
+    if (result) {
+        *woken = (xHigherPriorityTaskWoken == pdTRUE);
+    }
+
+    return result;
+}
+
+bool
 queue_pop(queue_t q, void *el, system_tick_t ticks)
 {
     return xQueueReceive(q, el, ticks) == pdTRUE;

--- a/src/freertos-queue.c
+++ b/src/freertos-queue.c
@@ -25,20 +25,20 @@ queue_create(queue_t *q, size_t size, size_t elsize, const char *name)
 size_t
 queue_elements_count(queue_t q)
 {
-    return uxQueueMessagesWaiting(q);
+    return uxQueueMessagesWaiting((xQueueHandle)q);
 }
 
 bool
 queue_push(queue_t q, void *el, system_tick_t ticks)
 {
-    return xQueueSendToBack(q, el, ticks) == pdTRUE;
+    return xQueueSendToBack((xQueueHandle)q, el, ticks) == pdTRUE;
 }
 
 bool
 queue_push_to_front(queue_t q, void *el, system_tick_t ticks)
 {
 
-    return xQueueSendToFront(q, el, ticks) == pdTRUE;
+    return xQueueSendToFront((xQueueHandle)q, el, ticks) == pdTRUE;
 }
 
 bool
@@ -47,7 +47,7 @@ queue_isr_push(queue_t q, void *el, bool * const woken)
     portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
     bool result;
 
-    result = (xQueueSendToBackFromISR(q, el,
+    result = (xQueueSendToBackFromISR((xQueueHandle)q, el,
                                       &xHigherPriorityTaskWoken) == pdTRUE);
     if (result) {
         *woken = (xHigherPriorityTaskWoken == pdTRUE);
@@ -59,5 +59,5 @@ queue_isr_push(queue_t q, void *el, bool * const woken)
 bool
 queue_pop(queue_t q, void *el, system_tick_t ticks)
 {
-    return xQueueReceive(q, el, ticks) == pdTRUE;
+    return xQueueReceive((xQueueHandle)q, el, ticks) == pdTRUE;
 }

--- a/src/freertos-smphr.c
+++ b/src/freertos-smphr.c
@@ -1,0 +1,56 @@
+#include <system/system.h>
+#include <system/smphr.h>
+
+#include <FreeRTOS/FreeRTOS.h>
+#include <FreeRTOS/task.h>
+#include <FreeRTOS/semphr.h>
+
+#include <stdbool.h>
+
+bool
+smphr_init(smphr_t *s, bool taken, const char *name)
+{
+    xSemaphoreHandle handle;
+
+    vSemaphoreCreateBinary(handle);
+    if (handle == NULL) {
+        return false;
+    }
+    if (taken) {
+        if (xSemaphoreTake(handle, 0) != pdTRUE) {
+            return false;
+        }
+    }
+    if (name != NULL) {
+        vQueueAddToRegistry(handle, (signed char *)name);
+    }
+    *s = (smphr_t)handle;
+
+    return true;
+}
+
+bool
+smphr_take(smphr_t s, system_tick_t ticks)
+{
+    return xSemaphoreTake(s, ticks) == pdTRUE;
+}
+
+bool
+smphr_give(smphr_t s)
+{
+    return xSemaphoreGive(s) == pdTRUE;
+}
+
+bool
+smphr_isr_give(smphr_t s, bool * const woken)
+{
+    portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
+    bool result;
+
+    result = (xSemaphoreGiveFromISR(s, &xHigherPriorityTaskWoken) == pdTRUE);
+    if (result) {
+        *woken = (xHigherPriorityTaskWoken == pdTRUE);
+    }
+
+    return result;
+}

--- a/src/freertos-smphr.c
+++ b/src/freertos-smphr.c
@@ -6,6 +6,7 @@
 #include <FreeRTOS/semphr.h>
 
 #include <stdbool.h>
+#include <stddef.h>
 
 bool
 smphr_init(smphr_t *s, bool taken, const char *name)
@@ -32,13 +33,13 @@ smphr_init(smphr_t *s, bool taken, const char *name)
 bool
 smphr_take(smphr_t s, system_tick_t ticks)
 {
-    return xSemaphoreTake(s, ticks) == pdTRUE;
+    return xSemaphoreTake((xSemaphoreHandle)s, ticks) == pdTRUE;
 }
 
 bool
 smphr_give(smphr_t s)
 {
-    return xSemaphoreGive(s) == pdTRUE;
+    return xSemaphoreGive((xSemaphoreHandle)s) == pdTRUE;
 }
 
 bool
@@ -47,7 +48,8 @@ smphr_isr_give(smphr_t s, bool * const woken)
     portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
     bool result;
 
-    result = (xSemaphoreGiveFromISR(s, &xHigherPriorityTaskWoken) == pdTRUE);
+    result = (xSemaphoreGiveFromISR((xSemaphoreHandle)s,
+                                     &xHigherPriorityTaskWoken) == pdTRUE);
     if (result) {
         *woken = (xHigherPriorityTaskWoken == pdTRUE);
     }

--- a/src/freertos-system.c
+++ b/src/freertos-system.c
@@ -23,3 +23,34 @@ system_delay(system_tick_t ticks)
 {
     vTaskDelay(ticks);
 }
+
+void
+system_delay_ms(system_tick_t ms)
+{
+#if (configTICK_RATE_HZ == 1000)
+    vTaskDelay(ms);
+#elif (configTICK_RATE_HZ == 500)
+    vTaskDelay(ms >> 1)
+#else
+    #error "Tick rate not supported!"
+#endif
+}
+
+system_tick_t
+system_get_tick_count(void)
+{
+    return xTaskGetTickCount();
+}
+
+system_tick_t
+system_get_tick_ms(void)
+{
+#if (configTICK_RATE_HZ == 1000)
+    return xTaskGetTickCount();
+#elif (configTICK_RATE_HZ == 500)
+    return (xTaskGetTickCount() << 1);
+#else
+    #error "Tick rate not supported!"
+#endif
+}
+

--- a/src/freertos-task.c
+++ b/src/freertos-task.c
@@ -34,7 +34,7 @@ task_destroy(task_t t)
 {
 #if (INCLUDE_vTaskDelete == 1)
     if(t != NULL) {
-        vTaskDelete(t);
+        vTaskDelete((xTaskHandle)t);
     }
 #endif /* INCLUDE_vTaskDelete == 1 */
 }

--- a/src/freertos-task.c
+++ b/src/freertos-task.c
@@ -22,7 +22,8 @@ task_create(task_t *t, task_routine_t rt, void *arg, const char * const tname,
         return false;
     }
 
-    result = xTaskCreate(rt, tname, (unsigned short)stack_size, tskIDLE_PRIORITY + arg, prio, &handle);
+    result = xTaskCreate((pdTASK_CODE)rt, (signed char *)tname,
+        (unsigned short)stack_size, arg, tskIDLE_PRIORITY + prio, &handle);
     *t = (task_t)handle;
 
     return result == pdTRUE;
@@ -49,3 +50,4 @@ task_delay_ticks(system_tick_t ticks)
 {
     vTaskDelay(ticks);
 }
+

--- a/src/freertos-timer.c
+++ b/src/freertos-timer.c
@@ -5,14 +5,17 @@
 #include <FreeRTOS/timers.h>
 
 #include <stdbool.h>
+#include <stddef.h>
+
+#define TMR_CREATE_DEFAULT_PERIOD            (1/*portMAX_DELAY*/)
 
 bool
-tmr_create(tmr_t *t, bool autoreload, timer_callback_t callback,
+tmr_init(tmr_t *t, bool autoreload, timer_callback_t callback,
              const char *name)
 {
     xTimerHandle handle;
 
-    handle = xTimerCreate((signed char *)name, 1, autoreload, t, callback);
+    handle = xTimerCreate((signed char *)name, TMR_CREATE_DEFAULT_PERIOD, autoreload, t, callback);
     if (handle == NULL) {
         return (false);
     }

--- a/src/freertos-timer.c
+++ b/src/freertos-timer.c
@@ -15,52 +15,45 @@ tmr_init(tmr_t *t, bool autoreload, timer_callback_t callback,
 {
     xTimerHandle handle;
 
-    handle = xTimerCreate((signed char *)name, TMR_CREATE_DEFAULT_PERIOD, autoreload, t, callback);
+    handle = xTimerCreate((signed char *)name, TMR_CREATE_DEFAULT_PERIOD,
+                          autoreload, t, callback);
     if (handle == NULL) {
         return (false);
     }
 
-    t->handle = handle;
-    t->period = 0;
+    *t = (tmr_t)handle;
 
     return (true);
 }
 
 bool
-tmr_start(tmr_t *t, system_tick_t period)
+tmr_start(tmr_t t, system_tick_t period)
 {
 
-    if (period != t->period) {
-        if (xTimerChangePeriod(t->handle, period, SYSTEM_NO_WAIT) != pdPASS) {
-            return (false);
-        }
-        t->period = period;
-    }
-
-    return (xTimerStart(t->handle, SYSTEM_NO_WAIT) == pdPASS);
-}
-
-bool
-tmr_reset(tmr_t *t)
-{
-
-    if (t->period == 0) {
+    if (xTimerChangePeriod((xTimerHandle)t, period, SYSTEM_NO_WAIT) != pdPASS) {
         return (false);
     }
 
-    return (xTimerReset(t->handle, SYSTEM_NO_WAIT) == pdPASS);
+    return (xTimerStart((xTimerHandle)t, SYSTEM_NO_WAIT) == pdPASS);
 }
 
 bool
-tmr_stop(tmr_t *t)
+tmr_reset(tmr_t t)
 {
 
-    return (xTimerStop(t->handle, SYSTEM_NO_WAIT) == pdPASS);
+    return (xTimerReset((xTimerHandle)t, SYSTEM_NO_WAIT) == pdPASS);
 }
 
 bool
-tmr_is_running(tmr_t *t)
+tmr_stop(tmr_t t)
 {
 
-    return (xTimerIsTimerActive(t->handle) != pdFALSE);
+    return (xTimerStop((xTimerHandle)t, SYSTEM_NO_WAIT) == pdPASS);
+}
+
+bool
+tmr_is_running(tmr_t t)
+{
+
+    return (xTimerIsTimerActive((xTimerHandle)t) != pdFALSE);
 }

--- a/src/freertos-timer.c
+++ b/src/freertos-timer.c
@@ -1,0 +1,63 @@
+#include <system/system.h>
+#include <system/timer.h>
+
+#include <FreeRTOS/FreeRTOS.h>
+#include <FreeRTOS/timers.h>
+
+#include <stdbool.h>
+
+bool
+tmr_create(tmr_t *t, bool autoreload, timer_callback_t callback,
+             const char *name)
+{
+    xTimerHandle handle;
+
+    handle = xTimerCreate((signed char *)name, 1, autoreload, t, callback);
+    if (handle == NULL) {
+        return (false);
+    }
+
+    t->handle = handle;
+    t->period = 0;
+
+    return (true);
+}
+
+bool
+tmr_start(tmr_t *t, system_tick_t period)
+{
+
+    if (period != t->period) {
+        if (xTimerChangePeriod(t->handle, period, SYSTEM_NO_WAIT) != pdPASS) {
+            return (false);
+        }
+        t->period = period;
+    }
+
+    return (xTimerStart(t->handle, SYSTEM_NO_WAIT) == pdPASS);
+}
+
+bool
+tmr_reset(tmr_t *t)
+{
+
+    if (t->period == 0) {
+        return (false);
+    }
+
+    return (xTimerReset(t->handle, SYSTEM_NO_WAIT) == pdPASS);
+}
+
+bool
+tmr_stop(tmr_t *t)
+{
+
+    return (xTimerStop(t->handle, SYSTEM_NO_WAIT) == pdPASS);
+}
+
+bool
+tmr_is_running(tmr_t *t)
+{
+
+    return (xTimerIsTimerActive(t->handle) != pdFALSE);
+}

--- a/src/posix-mutex.c
+++ b/src/posix-mutex.c
@@ -7,7 +7,7 @@
 bool
 mutex_init(mutex_t *m, const char *name)
 {
-    return smphr_init((smphr_t *)m, 1, name);
+    return smphr_init((smphr_t *)m, false, name);
 }
 
 bool

--- a/src/posix-queue.c
+++ b/src/posix-queue.c
@@ -28,7 +28,7 @@ queue_create(queue_t *queue, size_t size, size_t elsize, const char *name)
     }
     
     /* TODO: create names for queue mutex and sem */
-    if(!smphr_init(&q->sem, 0, NULL)) {
+    if(!smphr_init(&q->sem, true, NULL)) {
         goto error;
     }
 

--- a/src/posix-smphr.c
+++ b/src/posix-smphr.c
@@ -12,11 +12,11 @@
 #include <stdio.h>
 
 bool
-smphr_init(smphr_t *s, unsigned int value, const char *name)
+smphr_init(smphr_t *s, bool taken, const char *name)
 {
     *s = malloc(sizeof(sem_t));
 
-    return sem_init(*(sem_t **)s, 0, value) == 0;
+    return sem_init(*(sem_t **)s, 0, taken ? 0 : 1) == 0;
 }
 
 bool

--- a/src/posix-smphr.c
+++ b/src/posix-smphr.c
@@ -14,9 +14,10 @@
 bool
 smphr_init(smphr_t *s, bool taken, const char *name)
 {
+
     *s = malloc(sizeof(sem_t));
 
-    return sem_init(*(sem_t **)s, 0, taken ? 0 : 1) == 0;
+    return sem_init((sem_t *)*s, 0, taken ? 0 : 1) == 0;
 }
 
 bool
@@ -25,25 +26,25 @@ smphr_take(smphr_t s, system_tick_t ticks)
     struct timespec wait;
 
     if(ticks == SYSTEM_NO_WAIT) {
-        return sem_trywait(*(sem_t **)s) == 0;
+        return sem_trywait((sem_t *)s) == 0;
     }
 
     if(ticks == SYSTEM_MAX_WAIT) {
-        return sem_wait(*(sem_t **)s) == 0;
+        return sem_wait((sem_t *)s) == 0;
     }
 
     system_delay_to_timespec(ticks, &wait);
-    return sem_timedwait(*(sem_t **)s, &wait) == 0;
+    return sem_timedwait((sem_t *)s, &wait) == 0;
 }
 
 bool
 smphr_give(smphr_t s)
 {
-    return sem_post(*(sem_t **)s) == 0;
+    return sem_post((sem_t *)s) == 0;
 }
 
 void
 smphr_destroy(smphr_t s)
 {
-    free(*(sem_t **)s);
+    free((sem_t *)s);
 }

--- a/src/posix-system.c
+++ b/src/posix-system.c
@@ -51,6 +51,15 @@ system_delay_to_timespec(system_tick_t delay, struct timespec *ts)
     ts->tv_nsec %= NSEC_IN_SEC;
 }
 
+void
+system_delay(system_tick_t ticks)
+{
+    struct timespec delay;
+
+    system_ticks_to_timespec(ticks, &delay);
+    nanosleep(&delay, NULL);
+}
+
 system_tick_t
 system_get_tick_count(void)
 {

--- a/src/posix-system.c
+++ b/src/posix-system.c
@@ -26,7 +26,7 @@ system_init()
 
     memset(tasks, 0, sizeof(tasks));
 
-    tmr_init(&timer_task);
+    tmr_task_init(&timer_task);
 }
 
 void

--- a/src/posix-system.c
+++ b/src/posix-system.c
@@ -19,14 +19,17 @@ static unsigned int task_count = 0;
 static posix_task_t *tasks[SYSTEM_CONFIG_MAX_TASKS];
 static void *posix_task_wrapper(void *arg);
 
+#if (SYSTEM_CONFIG_USE_TIMERS == 1)
+static task_t timer_task;
+#endif
+
 void
 system_init()
 {
-    task_t timer_task;
-
     memset(tasks, 0, sizeof(tasks));
-
+#if (SYSTEM_CONFIG_USE_TIMERS == 1)
     tmr_task_init(&timer_task);
+#endif
 }
 
 void
@@ -117,7 +120,9 @@ system_start()
         task_destroy(tasks[i]);
     }
 
+#if (SYSTEM_CONFIG_USE_TIMERS == 1)
     tmr_destroy_list();
+#endif
 
     return retval;
 }

--- a/src/posix-system.c
+++ b/src/posix-system.c
@@ -117,6 +117,8 @@ system_start()
         task_destroy(tasks[i]);
     }
 
+    tmr_destroy_list();
+
     return retval;
 }
 

--- a/src/posix-system.c
+++ b/src/posix-system.c
@@ -11,6 +11,7 @@
 
 #include "posix-system.h"
 #include "posix-task.h"
+#include "posix-timer.h"
 
 #define NSEC_IN_SEC (1000000000L)
 
@@ -21,15 +22,19 @@ static void *posix_task_wrapper(void *arg);
 void
 system_init()
 {
+    task_t timer_task;
+
     memset(tasks, 0, sizeof(tasks));
+
+    tmr_init(&timer_task);
 }
 
 void
 system_ticks_to_timespec(system_tick_t ticks, struct timespec *ts)
 {
-    ts->tv_sec = ticks / SYSTEM_CONFIG_POSIX_TICKS_1S;
-    ticks %= SYSTEM_CONFIG_POSIX_TICKS_1S;
-    ts->tv_nsec = NSEC_IN_SEC / SYSTEM_CONFIG_POSIX_TICKS_1S * ticks;
+    ts->tv_sec = ticks / SYSTEM_TICK_RATE_MS;
+    ticks %= SYSTEM_TICK_RATE_MS;
+    ts->tv_nsec = NSEC_IN_SEC / SYSTEM_TICK_RATE_MS * ticks;
 }
 
 void
@@ -44,6 +49,16 @@ system_delay_to_timespec(system_tick_t delay, struct timespec *ts)
     ts->tv_sec += ct.tv_sec;
     ts->tv_sec += ts->tv_nsec / NSEC_IN_SEC;
     ts->tv_nsec %= NSEC_IN_SEC;
+}
+
+system_tick_t
+system_get_tick_count(void)
+{
+    struct timespec ct;
+
+    clock_gettime(CLOCK_REALTIME, &ct);
+    return (ct.tv_sec * SYSTEM_TICK_RATE_MS)
+        + (ct.tv_nsec / (NSEC_IN_SEC / SYSTEM_TICK_RATE_MS));
 }
 
 bool

--- a/src/posix-timer.c
+++ b/src/posix-timer.c
@@ -36,6 +36,24 @@ tmr_init(task_t *t)
     return (true);
 }
 
+void
+tmr_destroy(tmr_t t)
+{
+
+    free(t.handle);
+}
+
+void
+tmr_destroy_list()
+{
+
+    mutex_destroy(psx_tmr_mtx);
+    smphr_destroy(psx_tmr_s);
+
+    free(timer_list->handle);
+    free(timer_list);
+}
+
 void 
 tmr_run(void* arg)
 {
@@ -254,9 +272,4 @@ tmr_stop_locked(tmr_t *t)
     }
     return (true);
 }
-
-
-
-
-
 

--- a/src/posix-timer.c
+++ b/src/posix-timer.c
@@ -8,31 +8,31 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-static mutex_t psx_tmr_mtx;
-static smphr_t psx_tmr_s;
+static mutex_t tmr_psx_mtx;
+static smphr_t tmr_psx_s;
 
 static tmr_t *timer_list;
 
 static void tmr_run(void* arg);
-static bool delete_from_timer_list(tmr_t *timer_list, tmr_t *delete_timer);
-static bool add_to_timer_list(tmr_t *timer_list, tmr_t *new_timer);
+static bool tmr_delete_from_timer_list(tmr_t *timer_list, tmr_t *delete_timer);
+static bool tmr_add_to_timer_list(tmr_t *timer_list, tmr_t *new_timer);
 
 static bool tmr_stop_locked(tmr_t *t);
 static bool tmr_start_locked(tmr_t *t, system_tick_t period);
 
 bool 
-tmr_init(task_t *t)
+tmr_task_init(task_t *t)
 {
     
     task_create(t, tmr_run, NULL, NULL, 0, 0);
-    mutex_init(&psx_tmr_mtx, NULL);
-    smphr_init(&psx_tmr_s, true, NULL);
+    mutex_init(&tmr_psx_mtx, NULL);
+    smphr_init(&tmr_psx_s, true, NULL);
     
-    timer_list = (tmr_t*) malloc(sizeof(tmr_t));
-    timer_list->handle = (posix_timer_t*) malloc(sizeof(posix_timer_t));
-    ((posix_timer_t*)(timer_list->handle))->next_timer = NULL;
-    ((posix_timer_t*)(timer_list->handle))->prev_timer = NULL;
-    ((posix_timer_t*)(timer_list->handle))->wakeup_time = 0;
+    timer_list = (tmr_t *) malloc(sizeof(tmr_t));
+    timer_list->handle = (posix_timer_t *) malloc(sizeof(posix_timer_t));
+    ((posix_timer_t *)(timer_list->handle))->next_timer = NULL;
+    ((posix_timer_t *)(timer_list->handle))->prev_timer = NULL;
+    ((posix_timer_t *)(timer_list->handle))->wakeup_time = 0;
     return (true);
 }
 
@@ -47,25 +47,25 @@ void
 tmr_destroy_list()
 {
 
-    mutex_destroy(psx_tmr_mtx);
-    smphr_destroy(psx_tmr_s);
+    mutex_destroy(tmr_psx_mtx);
+    smphr_destroy(tmr_psx_s);
 
     free(timer_list->handle);
     free(timer_list);
 }
 
 void 
-tmr_run(void* arg)
+tmr_run(void *arg)
 {
     tmr_t *current_timer;
     posix_timer_t *current_posix_timer;
     system_tick_t ticks_to_callback, current_ticks;
     
-    while (1) {
-        mutex_lock(psx_tmr_mtx, SYSTEM_MAX_WAIT);
-        current_timer = ((posix_timer_t*)(timer_list->handle))->next_timer;
+    while (true) {
+        mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
+        current_timer = ((posix_timer_t *)(timer_list->handle))->next_timer;
         if (current_timer!=NULL) {
-            current_posix_timer = ((posix_timer_t*)(current_timer->handle));
+            current_posix_timer = ((posix_timer_t *)(current_timer->handle));
             current_ticks = system_get_tick_count();
             if (current_posix_timer->wakeup_time > current_ticks) {    
                 ticks_to_callback = current_posix_timer->wakeup_time - current_ticks;
@@ -75,10 +75,10 @@ tmr_run(void* arg)
         } else {
             ticks_to_callback = SYSTEM_MAX_WAIT;
         }
-        mutex_unlock(psx_tmr_mtx);
+        mutex_unlock(tmr_psx_mtx);
 
-        if (!smphr_take(psx_tmr_s, ticks_to_callback)) {
-            mutex_lock(psx_tmr_mtx, SYSTEM_MAX_WAIT);
+        if (!smphr_take(tmr_psx_s, ticks_to_callback)) {
+            mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
             if (current_timer != NULL) {
                 current_posix_timer->callback(NULL);
                 tmr_stop_locked(current_timer);
@@ -86,19 +86,17 @@ tmr_run(void* arg)
                     tmr_start_locked(current_timer, current_timer->period);
                 }
             }
-            mutex_unlock(psx_tmr_mtx);
+            mutex_unlock(tmr_psx_mtx);
         }    
     }
 }
 
-//-------------------------------------------------------------------------------
-
 bool
-tmr_create(tmr_t *t, bool autoreload, timer_callback_t callback,
+tmr_init(tmr_t *t, bool autoreload, timer_callback_t callback,
                   const char *name)
 {
     posix_timer_t *new_timer;
-    new_timer = (posix_timer_t*) malloc(sizeof(posix_timer_t));
+    new_timer = (posix_timer_t *) malloc(sizeof(posix_timer_t));
     
     if (!new_timer) {
         return (false);
@@ -122,8 +120,8 @@ tmr_start(tmr_t *t, system_tick_t period)
 {
     posix_timer_t *current_timer;
     
-    mutex_lock(psx_tmr_mtx, SYSTEM_MAX_WAIT);
-    current_timer = ((posix_timer_t*)(t->handle));
+    mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
+    current_timer = ((posix_timer_t *)(t->handle));
     
     if (current_timer->is_running == (true)) {
         tmr_stop_locked(t);
@@ -133,9 +131,9 @@ tmr_start(tmr_t *t, system_tick_t period)
     current_timer->wakeup_time = t->period + system_get_tick_count();
     current_timer->is_running = (true);
     
-    add_to_timer_list(timer_list, t);
-    smphr_give(psx_tmr_s);
-    mutex_unlock(psx_tmr_mtx);
+    tmr_add_to_timer_list(timer_list, t);
+    smphr_give(tmr_psx_s);
+    mutex_unlock(tmr_psx_mtx);
     return (true);
 }
 
@@ -143,12 +141,12 @@ bool
 tmr_reset(tmr_t *t)
 {
     
-    mutex_lock(psx_tmr_mtx, SYSTEM_MAX_WAIT);
+    mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
     if (!t->period){
-        mutex_unlock(psx_tmr_mtx);
+        mutex_unlock(tmr_psx_mtx);
         return (false);
     }
-    mutex_unlock(psx_tmr_mtx);
+    mutex_unlock(tmr_psx_mtx);
     return tmr_start(t, t->period);
 }
 
@@ -157,19 +155,19 @@ tmr_stop(tmr_t *t)
 {
     posix_timer_t *posix_timer;
     
-    mutex_lock(psx_tmr_mtx, SYSTEM_MAX_WAIT);
-    posix_timer = ((posix_timer_t*)(t->handle));
+    mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
+    posix_timer = ((posix_timer_t *)(t->handle));
     if (posix_timer->is_running) {
-        delete_from_timer_list(timer_list, t);
-        smphr_give(psx_tmr_s);
+        tmr_delete_from_timer_list(timer_list, t);
+        smphr_give(tmr_psx_s);
         
         posix_timer->wakeup_time = 0;
         posix_timer->is_running = (false);
-        mutex_unlock(psx_tmr_mtx);
+        mutex_unlock(tmr_psx_mtx);
         
         return (true);
     }
-    mutex_unlock(psx_tmr_mtx);
+    mutex_unlock(tmr_psx_mtx);
     return (true);
 }
 
@@ -178,35 +176,33 @@ tmr_is_running(tmr_t *t)
 {
     bool state;
     
-    mutex_lock(psx_tmr_mtx, SYSTEM_MAX_WAIT);
-    state = ((posix_timer_t*)(t->handle))->is_running;
-    mutex_unlock(psx_tmr_mtx);
+    mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
+    state = ((posix_timer_t *)(t->handle))->is_running;
+    mutex_unlock(tmr_psx_mtx);
     return state;
 }
 
-//-------------------------------------------------------------------------------
-
 bool
-add_to_timer_list(tmr_t *timer_list, tmr_t *new_timer)
+tmr_add_to_timer_list(tmr_t *timer_list, tmr_t *new_timer)
 {
     tmr_t *pointer, *next;
     posix_timer_t *current, *new;
     pointer = timer_list; 
     
-    new = ((posix_timer_t*)(new_timer->handle));
-    while (((posix_timer_t*)(pointer->handle))->next_timer != NULL)    {
-        current = ((posix_timer_t*)(pointer->handle));
+    new = ((posix_timer_t *)(new_timer->handle));
+    while (((posix_timer_t *)(pointer->handle))->next_timer != NULL)    {
+        current = ((posix_timer_t *)(pointer->handle));
         next = current->next_timer;    
-        if (((posix_timer_t*)(next->handle))->wakeup_time > new->wakeup_time) {
+        if (((posix_timer_t *)(next->handle))->wakeup_time > new->wakeup_time) {
             new->prev_timer = pointer;
             new->next_timer = current->next_timer;
             current->next_timer = new_timer;
-            ((posix_timer_t*)(next->handle))->prev_timer = new_timer;
+            ((posix_timer_t *)(next->handle))->prev_timer = new_timer;
             return (true);  
         } 
         pointer = current->next_timer;
     }
-    current = ((posix_timer_t*)(pointer->handle));
+    current = ((posix_timer_t *)(pointer->handle));
     new->prev_timer = pointer;
     new->next_timer = NULL;
     current->next_timer = new_timer;
@@ -215,22 +211,22 @@ add_to_timer_list(tmr_t *timer_list, tmr_t *new_timer)
 }
 
 bool
-delete_from_timer_list(tmr_t *timer_list, tmr_t *delete_timer)
+tmr_delete_from_timer_list(tmr_t *timer_list, tmr_t *delete_timer)
 {
     tmr_t *pointer, *next;
     posix_timer_t *current, *delete;
     pointer = timer_list; 
     
-    delete = ((posix_timer_t*)(delete_timer->handle));
-    current = ((posix_timer_t*)(pointer->handle));
+    delete = ((posix_timer_t *)(delete_timer->handle));
+    current = ((posix_timer_t *)(pointer->handle));
         
     while (current->next_timer != NULL)    {    
-        current = ((posix_timer_t*)(pointer->handle));
+        current = ((posix_timer_t *)(pointer->handle));
         if (current->next_timer == delete_timer) {
             next = delete->next_timer;
             current->next_timer = delete->next_timer;
             if (next != NULL){
-                ((posix_timer_t*)(next->handle))->prev_timer = delete->prev_timer;
+                ((posix_timer_t *)(next->handle))->prev_timer = delete->prev_timer;
             }
             return (true);  
         } 
@@ -244,14 +240,14 @@ tmr_start_locked(tmr_t *t, system_tick_t period)
 {
     posix_timer_t *current_timer;
     
-    current_timer = ((posix_timer_t*)(t->handle));
+    current_timer = ((posix_timer_t *)(t->handle));
         
     t->period = period;
     current_timer->wakeup_time = t->period + system_get_tick_count();
     current_timer->is_running = (true);
     
-    add_to_timer_list(timer_list, t);
-    smphr_give(psx_tmr_s);
+    tmr_add_to_timer_list(timer_list, t);
+    smphr_give(tmr_psx_s);
     return (true);
 }
 
@@ -260,10 +256,10 @@ tmr_stop_locked(tmr_t *t)
 {
     posix_timer_t *posix_timer;
     
-    posix_timer = ((posix_timer_t*)(t->handle));
+    posix_timer = ((posix_timer_t *)(t->handle));
     if (posix_timer->is_running) {
-        delete_from_timer_list(timer_list, t);
-        smphr_give(psx_tmr_s);
+        tmr_delete_from_timer_list(timer_list, t);
+        smphr_give(tmr_psx_s);
         
         posix_timer->wakeup_time = 0;
         posix_timer->is_running = (false);

--- a/src/posix-timer.c
+++ b/src/posix-timer.c
@@ -8,31 +8,35 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#define TMR_CREATE_DEFAULT_PERIOD               (1)
+
 static mutex_t tmr_psx_mtx;
 static smphr_t tmr_psx_s;
 
 static tmr_t *timer_list;
 
 static void tmr_run(void* arg);
-static bool tmr_delete_from_timer_list(tmr_t *timer_list, tmr_t *delete_timer);
-static bool tmr_add_to_timer_list(tmr_t *timer_list, tmr_t *new_timer);
+static bool tmr_delete_from_timer_list(tmr_t *timer_list, tmr_t delete_timer);
+static bool tmr_add_to_timer_list(tmr_t *timer_list, tmr_t new_timer);
 
-static bool tmr_stop_locked(tmr_t *t);
-static bool tmr_start_locked(tmr_t *t, system_tick_t period);
+static bool tmr_stop_locked(tmr_t t);
+static bool tmr_start_locked(tmr_t t, system_tick_t period);
+
+system_tick_t tmr_get_period(tmr_t t);
 
 bool 
 tmr_task_init(task_t *t)
 {
-    
+    posix_timer_t *tmr_list = (posix_timer_t *) malloc(sizeof(posix_timer_t));
+
     task_create(t, tmr_run, NULL, NULL, 0, 0);
     mutex_init(&tmr_psx_mtx, NULL);
     smphr_init(&tmr_psx_s, true, NULL);
-    
-    timer_list = (tmr_t *) malloc(sizeof(tmr_t));
-    timer_list->handle = (posix_timer_t *) malloc(sizeof(posix_timer_t));
-    ((posix_timer_t *)(timer_list->handle))->next_timer = NULL;
-    ((posix_timer_t *)(timer_list->handle))->prev_timer = NULL;
-    ((posix_timer_t *)(timer_list->handle))->wakeup_time = 0;
+
+    timer_list = (tmr_t *)tmr_list;
+    tmr_list->next_timer = NULL;
+    tmr_list->prev_timer = NULL;
+    tmr_list->wakeup_time = 0;
     return (true);
 }
 
@@ -40,7 +44,7 @@ void
 tmr_destroy(tmr_t t)
 {
 
-    free(t.handle);
+    free(t);
 }
 
 void
@@ -49,8 +53,6 @@ tmr_destroy_list()
 
     mutex_destroy(tmr_psx_mtx);
     smphr_destroy(tmr_psx_s);
-
-    free(timer_list->handle);
     free(timer_list);
 }
 
@@ -60,15 +62,16 @@ tmr_run(void *arg)
     tmr_t *current_timer;
     posix_timer_t *current_posix_timer;
     system_tick_t ticks_to_callback, current_ticks;
-    
+
     while (true) {
         mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
-        current_timer = ((posix_timer_t *)(timer_list->handle))->next_timer;
+        current_timer = ((posix_timer_t *)(timer_list))->next_timer;
         if (current_timer!=NULL) {
-            current_posix_timer = ((posix_timer_t *)(current_timer->handle));
+            current_posix_timer = ((posix_timer_t *)(current_timer));
             current_ticks = system_get_tick_count();
             if (current_posix_timer->wakeup_time > current_ticks) {    
-                ticks_to_callback = current_posix_timer->wakeup_time - current_ticks;
+                ticks_to_callback =
+                            current_posix_timer->wakeup_time - current_ticks;
             } else {
                 ticks_to_callback = SYSTEM_NO_WAIT;
             }
@@ -83,7 +86,7 @@ tmr_run(void *arg)
                 current_posix_timer->callback(NULL);
                 tmr_stop_locked(current_timer);
                 if (current_posix_timer->autoreload) {
-                    tmr_start_locked(current_timer, current_timer->period);
+                    tmr_start_locked(current_timer, current_posix_timer->period);
                 }
             }
             mutex_unlock(tmr_psx_mtx);
@@ -95,42 +98,36 @@ bool
 tmr_init(tmr_t *t, bool autoreload, timer_callback_t callback,
                   const char *name)
 {
-    posix_timer_t *new_timer;
-    new_timer = (posix_timer_t *) malloc(sizeof(posix_timer_t));
-    
+    posix_timer_t *new_timer = (posix_timer_t *)malloc(sizeof(posix_timer_t));
+
     if (!new_timer) {
         return (false);
     }
-    
+    *t = (tmr_t*)new_timer;
     new_timer->callback = callback;
     new_timer->autoreload = autoreload;
     new_timer->wakeup_time = SYSTEM_MAX_WAIT;
     new_timer->is_running = (false);
     new_timer->next_timer = NULL;
     new_timer->prev_timer = NULL;
-    
-    t->handle = (void*)new_timer;
-    t->period = 0;
-    
+    new_timer->period = TMR_CREATE_DEFAULT_PERIOD;
     return (true);                  
 }
 
 bool 
-tmr_start(tmr_t *t, system_tick_t period)
+tmr_start(tmr_t t, system_tick_t period)
 {
     posix_timer_t *current_timer;
-    
+
     mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
-    current_timer = ((posix_timer_t *)(t->handle));
-    
+    current_timer = (posix_timer_t *)t;
     if (current_timer->is_running == (true)) {
         tmr_stop_locked(t);
     }
-    
-    t->period = period;
-    current_timer->wakeup_time = t->period + system_get_tick_count();
+    current_timer->period = period;
+    current_timer->wakeup_time = current_timer->period + system_get_tick_count();
     current_timer->is_running = (true);
-    
+
     tmr_add_to_timer_list(timer_list, t);
     smphr_give(tmr_psx_s);
     mutex_unlock(tmr_psx_mtx);
@@ -138,33 +135,34 @@ tmr_start(tmr_t *t, system_tick_t period)
 }
 
 bool 
-tmr_reset(tmr_t *t)
+tmr_reset(tmr_t t)
 {
-    
+    posix_timer_t *current_timer;
+
     mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
-    if (!t->period){
+    current_timer = (posix_timer_t *)t;
+    if (!current_timer->period){
         mutex_unlock(tmr_psx_mtx);
         return (false);
     }
     mutex_unlock(tmr_psx_mtx);
-    return tmr_start(t, t->period);
+    return tmr_start(t, current_timer->period);
 }
 
 bool 
-tmr_stop(tmr_t *t)
+tmr_stop(tmr_t t)
 {
-    posix_timer_t *posix_timer;
-    
+    posix_timer_t *current_timer;
+
     mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
-    posix_timer = ((posix_timer_t *)(t->handle));
-    if (posix_timer->is_running) {
+    current_timer = (posix_timer_t *)t;
+    if (current_timer->is_running) {
         tmr_delete_from_timer_list(timer_list, t);
         smphr_give(tmr_psx_s);
         
-        posix_timer->wakeup_time = 0;
-        posix_timer->is_running = (false);
+        current_timer->wakeup_time = 0;
+        current_timer->is_running = (false);
         mutex_unlock(tmr_psx_mtx);
-        
         return (true);
     }
     mutex_unlock(tmr_psx_mtx);
@@ -172,61 +170,61 @@ tmr_stop(tmr_t *t)
 }
 
 bool 
-tmr_is_running(tmr_t *t)
+tmr_is_running(tmr_t t)
 {
+    posix_timer_t *current_timer;
     bool state;
-    
+
     mutex_lock(tmr_psx_mtx, SYSTEM_MAX_WAIT);
-    state = ((posix_timer_t *)(t->handle))->is_running;
+    current_timer = (posix_timer_t *)t;
+    state = current_timer->is_running;
     mutex_unlock(tmr_psx_mtx);
     return state;
 }
 
 bool
-tmr_add_to_timer_list(tmr_t *timer_list, tmr_t *new_timer)
+tmr_add_to_timer_list(tmr_t *timer_list, tmr_t new_timer)
 {
     tmr_t *pointer, *next;
     posix_timer_t *current, *new;
+
     pointer = timer_list; 
-    
-    new = ((posix_timer_t *)(new_timer->handle));
-    while (((posix_timer_t *)(pointer->handle))->next_timer != NULL)    {
-        current = ((posix_timer_t *)(pointer->handle));
+    new = (posix_timer_t *)(new_timer);
+    while (((posix_timer_t *)(pointer))->next_timer != NULL) {
+        current = (posix_timer_t *)pointer;
         next = current->next_timer;    
-        if (((posix_timer_t *)(next->handle))->wakeup_time > new->wakeup_time) {
+        if (((posix_timer_t *)(next))->wakeup_time > new->wakeup_time) {
             new->prev_timer = pointer;
             new->next_timer = current->next_timer;
             current->next_timer = new_timer;
-            ((posix_timer_t *)(next->handle))->prev_timer = new_timer;
+            ((posix_timer_t *)(next))->prev_timer = new_timer;
             return (true);  
         } 
         pointer = current->next_timer;
     }
-    current = ((posix_timer_t *)(pointer->handle));
+    current = (posix_timer_t *)pointer;
     new->prev_timer = pointer;
     new->next_timer = NULL;
     current->next_timer = new_timer;
-
     return (true);
 }
 
 bool
-tmr_delete_from_timer_list(tmr_t *timer_list, tmr_t *delete_timer)
+tmr_delete_from_timer_list(tmr_t *timer_list, tmr_t delete_timer)
 {
     tmr_t *pointer, *next;
     posix_timer_t *current, *delete;
     pointer = timer_list; 
-    
-    delete = ((posix_timer_t *)(delete_timer->handle));
-    current = ((posix_timer_t *)(pointer->handle));
-        
-    while (current->next_timer != NULL)    {    
-        current = ((posix_timer_t *)(pointer->handle));
+
+    delete = (posix_timer_t *)delete_timer;
+    current = (posix_timer_t *)pointer;
+    while (current->next_timer != NULL) {
+        current = (posix_timer_t *)pointer;
         if (current->next_timer == delete_timer) {
             next = delete->next_timer;
             current->next_timer = delete->next_timer;
             if (next != NULL){
-                ((posix_timer_t *)(next->handle))->prev_timer = delete->prev_timer;
+                ((posix_timer_t *)(next))->prev_timer = delete->prev_timer;
             }
             return (true);  
         } 
@@ -236,36 +234,32 @@ tmr_delete_from_timer_list(tmr_t *timer_list, tmr_t *delete_timer)
 }
 
 bool 
-tmr_start_locked(tmr_t *t, system_tick_t period)
+tmr_start_locked(tmr_t t, system_tick_t period)
 {
     posix_timer_t *current_timer;
-    
-    current_timer = ((posix_timer_t *)(t->handle));
-        
-    t->period = period;
-    current_timer->wakeup_time = t->period + system_get_tick_count();
+
+    current_timer = (posix_timer_t *)t;
+    current_timer->period = period;
+    current_timer->wakeup_time = current_timer->period + system_get_tick_count();
     current_timer->is_running = (true);
-    
     tmr_add_to_timer_list(timer_list, t);
     smphr_give(tmr_psx_s);
     return (true);
 }
 
 bool 
-tmr_stop_locked(tmr_t *t)
+tmr_stop_locked(tmr_t t)
 {
-    posix_timer_t *posix_timer;
-    
-    posix_timer = ((posix_timer_t *)(t->handle));
-    if (posix_timer->is_running) {
+    posix_timer_t *current_timer;
+
+    current_timer = (posix_timer_t *)t;
+    if (current_timer->is_running) {
         tmr_delete_from_timer_list(timer_list, t);
         smphr_give(tmr_psx_s);
         
-        posix_timer->wakeup_time = 0;
-        posix_timer->is_running = (false);
-        
+        current_timer->wakeup_time = 0;
+        current_timer->is_running = (false);
         return (true);
     }
     return (true);
 }
-

--- a/src/posix-timer.c
+++ b/src/posix-timer.c
@@ -22,8 +22,6 @@ static bool tmr_add_to_timer_list(tmr_t *timer_list, tmr_t new_timer);
 static bool tmr_stop_locked(tmr_t t);
 static bool tmr_start_locked(tmr_t t, system_tick_t period);
 
-system_tick_t tmr_get_period(tmr_t t);
-
 bool 
 tmr_task_init(task_t *t)
 {

--- a/src/posix-timer.c
+++ b/src/posix-timer.c
@@ -1,0 +1,262 @@
+#include <system/system.h>
+#include <system/task.h>
+#include <system/mutex.h>
+#include <system/smphr.h>
+
+#include "posix-timer.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+static mutex_t psx_tmr_mtx;
+static smphr_t psx_tmr_s;
+
+static tmr_t *timer_list;
+
+static void tmr_run(void* arg);
+static bool delete_from_timer_list(tmr_t *timer_list, tmr_t *delete_timer);
+static bool add_to_timer_list(tmr_t *timer_list, tmr_t *new_timer);
+
+static bool tmr_stop_locked(tmr_t *t);
+static bool tmr_start_locked(tmr_t *t, system_tick_t period);
+
+bool 
+tmr_init(task_t *t)
+{
+    
+    task_create(t, tmr_run, NULL, NULL, 0, 0);
+    mutex_init(&psx_tmr_mtx, NULL);
+    smphr_init(&psx_tmr_s, true, NULL);
+    
+    timer_list = (tmr_t*) malloc(sizeof(tmr_t));
+    timer_list->handle = (posix_timer_t*) malloc(sizeof(posix_timer_t));
+    ((posix_timer_t*)(timer_list->handle))->next_timer = NULL;
+    ((posix_timer_t*)(timer_list->handle))->prev_timer = NULL;
+    ((posix_timer_t*)(timer_list->handle))->wakeup_time = 0;
+    return (true);
+}
+
+void 
+tmr_run(void* arg)
+{
+    tmr_t *current_timer;
+    posix_timer_t *current_posix_timer;
+    system_tick_t ticks_to_callback, current_ticks;
+    
+    while (1) {
+        mutex_lock(&psx_tmr_mtx, SYSTEM_MAX_WAIT);
+        current_timer = ((posix_timer_t*)(timer_list->handle))->next_timer;
+        if (current_timer!=NULL) {
+            current_posix_timer = ((posix_timer_t*)(current_timer->handle));
+            current_ticks = system_get_tick_count();
+            if (current_posix_timer->wakeup_time > current_ticks) {    
+                ticks_to_callback = current_posix_timer->wakeup_time - current_ticks;
+            } else {
+                ticks_to_callback = SYSTEM_NO_WAIT;
+            }
+        } else {
+            ticks_to_callback = SYSTEM_MAX_WAIT;
+        }
+        mutex_unlock(&psx_tmr_mtx);
+
+        if (!smphr_take(&psx_tmr_s, ticks_to_callback)) {
+            mutex_lock(&psx_tmr_mtx, SYSTEM_MAX_WAIT);
+            if (current_timer != NULL) {
+                current_posix_timer->callback(NULL);
+                tmr_stop_locked(current_timer);
+                if (current_posix_timer->autoreload) {
+                    tmr_start_locked(current_timer, current_timer->period);
+                }
+            }
+            mutex_unlock(&psx_tmr_mtx);
+        }    
+    }
+}
+
+//-------------------------------------------------------------------------------
+
+bool
+tmr_create(tmr_t *t, bool autoreload, timer_callback_t callback,
+                  const char *name)
+{
+    posix_timer_t *new_timer;
+    new_timer = (posix_timer_t*) malloc(sizeof(posix_timer_t));
+    
+    if (!new_timer) {
+        return (false);
+    }
+    
+    new_timer->callback = callback;
+    new_timer->autoreload = autoreload;
+    new_timer->wakeup_time = SYSTEM_MAX_WAIT;
+    new_timer->is_running = (false);
+    new_timer->next_timer = NULL;
+    new_timer->prev_timer = NULL;
+    
+    t->handle = (void*)new_timer;
+    t->period = 0;
+    
+    return (true);                  
+}
+
+bool 
+tmr_start(tmr_t *t, system_tick_t period)
+{
+    posix_timer_t *current_timer;
+    
+    mutex_lock(&psx_tmr_mtx, SYSTEM_MAX_WAIT);
+    current_timer = ((posix_timer_t*)(t->handle));
+    
+    if (current_timer->is_running == (true)) {
+        tmr_stop_locked(t);
+    }
+    
+    t->period = period;
+    current_timer->wakeup_time = t->period + system_get_tick_count();
+    current_timer->is_running = (true);
+    
+    add_to_timer_list(timer_list, t);
+    smphr_give(&psx_tmr_s);
+    mutex_unlock(&psx_tmr_mtx);
+    return (true);
+}
+
+bool 
+tmr_reset(tmr_t *t)
+{
+    
+    mutex_lock(&psx_tmr_mtx, SYSTEM_MAX_WAIT);
+    if (!t->period){
+        mutex_unlock(&psx_tmr_mtx);
+        return (false);
+    }
+    mutex_unlock(&psx_tmr_mtx);
+    return tmr_start(t, t->period);
+}
+
+bool 
+tmr_stop(tmr_t *t)
+{
+    posix_timer_t *posix_timer;
+    
+    mutex_lock(&psx_tmr_mtx, SYSTEM_MAX_WAIT);
+    posix_timer = ((posix_timer_t*)(t->handle));
+    if (posix_timer->is_running) {
+        delete_from_timer_list(timer_list, t);
+        smphr_give(&psx_tmr_s);
+        
+        posix_timer->wakeup_time = 0;
+        posix_timer->is_running = (false);
+        mutex_unlock(&psx_tmr_mtx);
+        
+        return (true);
+    }
+    mutex_unlock(&psx_tmr_mtx);
+    return (true);
+}
+
+bool 
+tmr_is_running(tmr_t *t)
+{
+    bool state;
+    
+    mutex_lock(&psx_tmr_mtx, SYSTEM_MAX_WAIT);
+    state = ((posix_timer_t*)(t->handle))->is_running;
+    mutex_unlock(&psx_tmr_mtx);
+    return state;
+}
+
+//-------------------------------------------------------------------------------
+
+bool
+add_to_timer_list(tmr_t *timer_list, tmr_t *new_timer)
+{
+    tmr_t *pointer, *next;
+    posix_timer_t *current, *new;
+    pointer = timer_list; 
+    
+    new = ((posix_timer_t*)(new_timer->handle));
+    while (((posix_timer_t*)(pointer->handle))->next_timer != NULL)    {
+        current = ((posix_timer_t*)(pointer->handle));
+        next = current->next_timer;    
+        if (((posix_timer_t*)(next->handle))->wakeup_time > new->wakeup_time) {
+            new->prev_timer = pointer;
+            new->next_timer = current->next_timer;
+            current->next_timer = new_timer;
+            ((posix_timer_t*)(next->handle))->prev_timer = new_timer;
+            return (true);  
+        } 
+        pointer = current->next_timer;
+    }
+    current = ((posix_timer_t*)(pointer->handle));
+    new->prev_timer = pointer;
+    new->next_timer = NULL;
+    current->next_timer = new_timer;
+
+    return (true);
+}
+
+bool
+delete_from_timer_list(tmr_t *timer_list, tmr_t *delete_timer)
+{
+    tmr_t *pointer, *next;
+    posix_timer_t *current, *delete;
+    pointer = timer_list; 
+    
+    delete = ((posix_timer_t*)(delete_timer->handle));
+    current = ((posix_timer_t*)(pointer->handle));
+        
+    while (current->next_timer != NULL)    {    
+        current = ((posix_timer_t*)(pointer->handle));
+        if (current->next_timer == delete_timer) {
+            next = delete->next_timer;
+            current->next_timer = delete->next_timer;
+            if (next != NULL){
+                ((posix_timer_t*)(next->handle))->prev_timer = delete->prev_timer;
+            }
+            return (true);  
+        } 
+        pointer = current->next_timer;
+    }
+    return (false);
+}
+
+bool 
+tmr_start_locked(tmr_t *t, system_tick_t period)
+{
+    posix_timer_t *current_timer;
+    
+    current_timer = ((posix_timer_t*)(t->handle));
+        
+    t->period = period;
+    current_timer->wakeup_time = t->period + system_get_tick_count();
+    current_timer->is_running = (true);
+    
+    add_to_timer_list(timer_list, t);
+    smphr_give(&psx_tmr_s);
+    return (true);
+}
+
+bool 
+tmr_stop_locked(tmr_t *t)
+{
+    posix_timer_t *posix_timer;
+    
+    posix_timer = ((posix_timer_t*)(t->handle));
+    if (posix_timer->is_running) {
+        delete_from_timer_list(timer_list, t);
+        smphr_give(&psx_tmr_s);
+        
+        posix_timer->wakeup_time = 0;
+        posix_timer->is_running = (false);
+        
+        return (true);
+    }
+    return (true);
+}
+
+
+
+
+
+

--- a/src/posix-timer.h
+++ b/src/posix-timer.h
@@ -1,0 +1,23 @@
+#ifndef __SYSTEM_POSIX_TIMER_H__
+#define __SYSTEM_POSIX_TIMER_H__
+
+#include <system/base.h>
+#include <system/task.h>
+#include "timer.h"
+#include <stdbool.h>
+
+typedef struct {
+    tmr_t *next_timer;
+    tmr_t *prev_timer;
+    
+    timer_callback_t callback;
+    system_tick_t period;
+    system_tick_t wakeup_time;
+    bool autoreload;
+    bool is_running;
+ 
+} posix_timer_t;
+
+bool tmr_init(task_t *t);
+
+#endif /* __SYSTEM_POSIX_TIMER_H__ */

--- a/src/posix-timer.h
+++ b/src/posix-timer.h
@@ -19,5 +19,6 @@ typedef struct {
 } posix_timer_t;
 
 bool tmr_init(task_t *t);
+void tmr_destroy_list();
 
 #endif /* __SYSTEM_POSIX_TIMER_H__ */

--- a/src/posix-timer.h
+++ b/src/posix-timer.h
@@ -18,7 +18,7 @@ typedef struct {
  
 } posix_timer_t;
 
-bool tmr_init(task_t *t);
+bool tmr_task_init(task_t *t);
 void tmr_destroy_list();
 
 #endif /* __SYSTEM_POSIX_TIMER_H__ */

--- a/src/queue.h
+++ b/src/queue.h
@@ -13,6 +13,8 @@ typedef void* queue_t;
 bool queue_create(queue_t *q, size_t size, size_t elsize, const char *name);
 size_t queue_elements_count(queue_t q);
 bool queue_push(queue_t q, void *el, system_tick_t ticks);
+bool queue_push_to_front(queue_t q, void *el, system_tick_t ticks);
+bool queue_isr_push(queue_t q, void *el, bool * const woken);
 bool queue_pop(queue_t q, void *el, system_tick_t ticks);
 void queue_destroy(queue_t q);
 

--- a/src/smphr.h
+++ b/src/smphr.h
@@ -6,9 +6,10 @@
 
 typedef void *smphr_t;
 
-bool smphr_init(smphr_t *s, unsigned int value, const char *name);
+bool smphr_init(smphr_t *s, bool taken, const char *name);
 bool smphr_take(smphr_t s, system_tick_t ticks);
 bool smphr_give(smphr_t s);
+bool smphr_isr_give(smphr_t s, bool * const woken);
 void smphr_destroy(smphr_t s);
 
 #endif /* __SYSTEM_SMPHR_H__ */

--- a/src/system.h
+++ b/src/system.h
@@ -7,6 +7,11 @@
 /* public methods */
 void system_init(void);
 bool system_start(void);
+
 void system_delay(system_tick_t);
+void system_delay_ms(system_tick_t ms);
+
+system_tick_t system_get_tick_count(void);
+system_tick_t system_get_tick_ms(void);
 
 #endif /* __SYSTEM_SYSTEM_H__ */

--- a/src/task.h
+++ b/src/task.h
@@ -12,8 +12,8 @@ typedef void* task_t;
 /* task routine */
 typedef SYSTEM_TASK_MODIFIER void (*task_routine_t)(void *arg);
 
-bool task_create(task_t *tsk, task_routine_t rt, void *arg, const char * const tname,
-        unsigned int prio, size_t stack_size);
+bool task_create(task_t *tsk, task_routine_t rt, void *arg,
+        const char * const tname, unsigned int prio, size_t stack_size);
 void task_destroy(task_t tsk);
 
 #endif /* __SYSTEM_TASK_H__ */

--- a/src/timer.h
+++ b/src/timer.h
@@ -13,7 +13,7 @@ typedef void (*timer_callback_t)(void *handle);
 
 
 
-bool tmr_create(tmr_t *t, bool autoreload, timer_callback_t callback,
+bool tmr_init(tmr_t *t, bool autoreload, timer_callback_t callback,
                   const char *name);
 bool tmr_start(tmr_t *t, system_tick_t period);
 bool tmr_isr_start(tmr_t *t, bool * const woken);

--- a/src/timer.h
+++ b/src/timer.h
@@ -1,0 +1,26 @@
+#ifndef __SYSTEM_TIMER_H__
+#define __SYSTEM_TIMER_H__
+
+#include <system/base.h>
+#include <stdbool.h>
+
+typedef struct {
+    void *handle;
+    system_tick_t period;
+} tmr_t;
+
+typedef void (*timer_callback_t)(void *handle);
+
+
+
+bool tmr_create(tmr_t *t, bool autoreload, timer_callback_t callback,
+                  const char *name);
+bool tmr_start(tmr_t *t, system_tick_t period);
+bool tmr_isr_start(tmr_t *t, bool * const woken);
+bool tmr_reset(tmr_t *t);
+bool tmr_isr_reset(tmr_t *t, bool * const woken);
+bool tmr_stop(tmr_t *t);
+bool tmr_isr_stop(tmr_t *t, bool * const woken);
+bool tmr_is_running(tmr_t *t);
+
+#endif /* __SYSTEM_TIMER_H__ */

--- a/src/timer.h
+++ b/src/timer.h
@@ -4,25 +4,21 @@
 #include <system/base.h>
 #include <stdbool.h>
 
-typedef struct {
-    void *handle;
-    system_tick_t period;
-} tmr_t;
+typedef void* tmr_t;
 
 typedef void (*timer_callback_t)(void *handle);
 
-
-
 bool tmr_init(tmr_t *t, bool autoreload, timer_callback_t callback,
                   const char *name);
-bool tmr_start(tmr_t *t, system_tick_t period);
-bool tmr_isr_start(tmr_t *t, bool * const woken);
-bool tmr_reset(tmr_t *t);
-bool tmr_isr_reset(tmr_t *t, bool * const woken);
-bool tmr_stop(tmr_t *t);
-bool tmr_isr_stop(tmr_t *t, bool * const woken);
-bool tmr_is_running(tmr_t *t);
+bool tmr_start(tmr_t t, system_tick_t period);
+bool tmr_isr_start(tmr_t t, bool * const woken);
+bool tmr_reset(tmr_t t);
+bool tmr_isr_reset(tmr_t t, bool * const woken);
+bool tmr_stop(tmr_t t);
+bool tmr_isr_stop(tmr_t t, bool * const woken);
+bool tmr_is_running(tmr_t t);
 
+system_tick_t tmr_get_period(tmr_t t);
 void tmr_destroy(tmr_t t);
 
 #endif /* __SYSTEM_TIMER_H__ */

--- a/src/timer.h
+++ b/src/timer.h
@@ -23,4 +23,6 @@ bool tmr_stop(tmr_t *t);
 bool tmr_isr_stop(tmr_t *t, bool * const woken);
 bool tmr_is_running(tmr_t *t);
 
+void tmr_destroy(tmr_t t);
+
 #endif /* __SYSTEM_TIMER_H__ */

--- a/src/timer.h
+++ b/src/timer.h
@@ -18,7 +18,6 @@ bool tmr_stop(tmr_t t);
 bool tmr_isr_stop(tmr_t t, bool * const woken);
 bool tmr_is_running(tmr_t t);
 
-system_tick_t tmr_get_period(tmr_t t);
 void tmr_destroy(tmr_t t);
 
 #endif /* __SYSTEM_TIMER_H__ */


### PR DESCRIPTION
1) base.h -> zdefiniowanie SYSTEM_TICK_RATE_MS wraz z obsluga dla POSIX'a (wartosc dla niego 1000)
1a) Uzycie SYSTEM_TICK_RATE_MS zamiast SYSTEM_CONFIG_TICKS_1S (posix-system.c)
2) Zmiany argumentu funkcji smphr_init (uns. int value -> bool taken)
2a) Odpowiednie zmiany w wywolaniach powyzszej funkcji ( !!!  0 -> true, 1->false !!!, dodanie stdbool.h)
3) Usuniecie nieodpowiedniego rzutowania w freertos-mutex.c
4) Dodanie dwoch funkcji dla freertos'owej kolejki (queue_push_to_front, queue_isr_push)
5) Przesuniecie funkcji związanych z delay'mi i tickami do *-system.c
5a) Dodanie funkcji system_get_tick_count
6) Poprawka bledu w argumentach dla xTaskCreate (freertos-task.c)
7) Dodanie inicjalizacji timerów w system_init() (posix-system.c)
8) Małe poprawki w stylistyce
9) Dodanie obsługi timerów dla POSIX'a
9a) Calosc opiera sie na jednym semaforze ktory czeka odpowiedni czas,
    Wywolanie funkcji start, stop, reset zwalnia semafor
    Timery sa dodawane do listy zgodnie z czasem "wybudzenia" (nie musimy przeszukiwac listy)
